### PR TITLE
fix #1: Correctly update local variable instead of global

### DIFF
--- a/src/Environment.kt
+++ b/src/Environment.kt
@@ -29,22 +29,16 @@ class Environment {
     fun assign(name: Token, value: Any?) {
         if (values.containsKey(name.lexeme)) {
             values[name.lexeme] = value
-            return
+        } else {
+            define(name.lexeme, value)
         }
-
-        if (enclosing != null) {
-            enclosing?.assign(name, value)
-            return
-        }
-
-        define(name.lexeme, value)
     }
 
     fun getAt(distance: Int, name: String): Any? {
         return ancestor(distance).values[name]
     }
 
-    fun ancestor(distance: Int): Environment {
+    private fun ancestor(distance: Int): Environment {
         var environment = this
         for (i in 0 until distance) {
             environment = environment.enclosing!!

--- a/src/Interpreter.kt
+++ b/src/Interpreter.kt
@@ -44,8 +44,8 @@ class Interpreter : Expr.Visitor<Any?>, Stmt.Visitor<Any?> {
     }
 
     override fun visitBinaryExpr(expr: Expr.Binary): Any? {
-        var left = evaluate(expr.left)
-        var right = evaluate(expr.right)
+        val left = evaluate(expr.left)
+        val right = evaluate(expr.right)
 
         return when(expr.operator.type){
             TokenType.PLUS -> {
@@ -76,7 +76,7 @@ class Interpreter : Expr.Visitor<Any?>, Stmt.Visitor<Any?> {
         return evaluate(expr.expression)
     }
 
-    override fun visitLiteralExpr(expr: Expr.Literal): Any? {
+    override fun visitLiteralExpr(expr: Expr.Literal): Any {
         return expr.value
     }
 
@@ -158,10 +158,10 @@ class Interpreter : Expr.Visitor<Any?>, Stmt.Visitor<Any?> {
 
     private fun lookUpVariable(name: Token, expr: Expr): Any? {
         val distance = locals[expr]
-        if(distance != null){
-            return environment.getAt(distance, name.lexeme)
+        return if(distance != null){
+            environment.getAt(distance, name.lexeme)
         } else {
-            return environment.get(name)
+            environment.get(name)
         }
     }
 }

--- a/src/Parser.kt
+++ b/src/Parser.kt
@@ -29,7 +29,7 @@ class Parser(private var tokens: List<Token>) {
     }
 
     private fun assignment(): Expr {
-        var expr = term()
+        val expr = term()
 
         if (match(TokenType.EQUAL)) {
             val equals = previous()
@@ -206,7 +206,7 @@ class Parser(private var tokens: List<Token>) {
 
     private fun ignoreNewLines() {
         while (match(TokenType.NEW_LINE)) {
-
+            // Ignore newlines in "scope", because scope doesn't end after a newline
         }
     }
 }

--- a/src/Resolver.kt
+++ b/src/Resolver.kt
@@ -3,29 +3,29 @@ package src
 class Resolver(private var interpreter: Interpreter) : Expr.Visitor<Unit>, Stmt.Visitor<Unit> {
     private val scopes = mutableListOf<HashMap<String, Boolean>>()
 
-    override fun visitAssignExpr(expr: Expr.Assign): Unit {
+    override fun visitAssignExpr(expr: Expr.Assign) {
         resolve(expr.value)
         resolveLocal(expr, expr.name)
     }
 
-    override fun visitBinaryExpr(expr: Expr.Binary): Unit {
+    override fun visitBinaryExpr(expr: Expr.Binary) {
         resolve(expr.left)
         resolve(expr.right)
     }
 
-    override fun visitGroupingExpr(expr: Expr.Grouping): Unit {
+    override fun visitGroupingExpr(expr: Expr.Grouping) {
         resolve(expr.expression)
     }
 
-    override fun visitLiteralExpr(expr: Expr.Literal): Unit {
+    override fun visitLiteralExpr(expr: Expr.Literal) {
         return
     }
 
-    override fun visitUnaryExpr(expr: Expr.Unary): Unit {
+    override fun visitUnaryExpr(expr: Expr.Unary) {
         resolve(expr.right)
     }
 
-    override fun visitVariableExpr(expr: Expr.Variable): Unit {
+    override fun visitVariableExpr(expr: Expr.Variable) {
         if(scopes.isNotEmpty()){
             if(scopes.last()[expr.name.lexeme] == false){
                 Suljaga.error(expr.name, "Cannot read local variable in its own initializer.")
@@ -35,21 +35,21 @@ class Resolver(private var interpreter: Interpreter) : Expr.Visitor<Unit>, Stmt.
         resolveLocal(expr, expr.name)
     }
 
-    override fun visitBlockStmt(stmt: Stmt.Block) : Unit {
+    override fun visitBlockStmt(stmt: Stmt.Block) {
         beginScope()
         resolve(stmt.statements)
         endScope()
     }
 
-    override fun visitExpressionStmt(stmt: Stmt.Expression): Unit {
+    override fun visitExpressionStmt(stmt: Stmt.Expression) {
         resolve(stmt.expression)
     }
 
-    override fun visitPrintStmt(stmt: Stmt.Print): Unit {
+    override fun visitPrintStmt(stmt: Stmt.Print) {
         resolve(stmt.expression)
     }
 
-    override fun visitVarStmt(stmt: Stmt.Var): Unit {
+    override fun visitVarStmt(stmt: Stmt.Var) {
         declare(stmt.name)
         resolve(stmt.initializer)
         define(stmt.name)
@@ -80,20 +80,20 @@ class Resolver(private var interpreter: Interpreter) : Expr.Visitor<Unit>, Stmt.
     private fun declare(name : Token){
         if(scopes.isEmpty()) return
 
-        var scope = scopes.last()
+        val scope = scopes.last()
         scope[name.lexeme] = false
     }
 
     private fun define(name : Token){
         if(scopes.isEmpty()) return
 
-        var scope = scopes.last()
+        val scope = scopes.last()
         scope[name.lexeme] = true
     }
 
-    private fun resolveLocal(expr: Expr, name: Token){
-        for(i in scopes.size - 1 downTo 0){
-            if(scopes[i].containsKey(name.lexeme)){
+    private fun resolveLocal(expr: Expr, name: Token) {
+        for (i in scopes.size - 1 downTo 0) {
+            if (scopes[i].containsKey(name.lexeme)) {
                 interpreter.resolve(expr, scopes.size - 1 - i)
                 return
             }


### PR DESCRIPTION
This PR fixes the incorrect handling of variable scope as described in issue #1.

### Changes:
- Ensures that, if the variable didn't exist before in the scope, it initializes it instead of referencing a global variable

### Closes:
Close #1